### PR TITLE
On RestartApp enclose exeToStart with quotes

### DIFF
--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -188,6 +188,9 @@ namespace Squirrel
             //    we take the app's *name* rather than a full path)
 
             exeToStart = exeToStart ?? Path.GetFileName(Assembly.GetEntryAssembly().Location);
+            if (exeToStart.Contains(" ") && !(exeToStart.StartsWith("\"") && exeToStart.EndsWith("\"")))
+                exeToStart = String.Format("\"{0}\"", exeToStart);
+                
             var argsArg = arguments != null ?
                 String.Format("-a \"{0}\"", arguments) : "";
 
@@ -216,6 +219,9 @@ namespace Squirrel
             //    we take the app's *name* rather than a full path)
 
             exeToStart = exeToStart ?? Path.GetFileName(Assembly.GetEntryAssembly().Location);
+            if (exeToStart.Contains(" ") && !(exeToStart.StartsWith("\"") && exeToStart.EndsWith("\"")))
+                exeToStart = String.Format("\"{0}\"", exeToStart);
+                
             var argsArg = arguments != null ?
                 String.Format("-a \"{0}\"", arguments) : "";
 


### PR DESCRIPTION
On RestartApp enclose exeToStart with double-quotes when needed (exe-name contains spaces, and it's not contained within double-quotes by the caller)